### PR TITLE
Fix Point import issues from rusty-maths update

### DIFF
--- a/src/modules/bezier_curve.rs
+++ b/src/modules/bezier_curve.rs
@@ -1,9 +1,8 @@
 use super::{
-    common::{get_braille, make_cell_matrix, CellMatrix, CharMatrix, GraphOptions},
+    common::{get_braille, make_cell_matrix, CellMatrix, CharMatrix, GraphOptions, Point},
     logger::Logger,
     string_maker::make_curve_string,
 };
-use rusty_maths::equation_analyzer::calculator::Point;
 
 const STEP_SIZE: f32 = 0.001;
 

--- a/src/modules/commands.rs
+++ b/src/modules/commands.rs
@@ -3,8 +3,6 @@ use rusty_maths::{
     linear_algebra::{vector_mean, vector_sum},
 };
 
-use rusty_maths::equation_analyzer::calculator::Point;
-
 use crate::modules::{
     common::*,
     cube::cube,
@@ -130,7 +128,11 @@ fn t(l: &mut impl Logger) {
 
     let points = plot(&eq, x_min, x_max, step_size);
 
-    if let Ok(points) = points {
+    if let Ok(rm_points) = points {
+        let points: Vec<_> = rm_points
+            .into_iter()
+            .map(|p| Point::new(p.x, p.y))
+            .collect();
         l.print(&make_table_string(points));
     } else if let Err(p) = points {
         l.eprint(&p);

--- a/src/modules/common.rs
+++ b/src/modules/common.rs
@@ -1,4 +1,19 @@
-use rusty_maths::equation_analyzer::calculator::Point;
+/// Represents a point in 2D space for plotting equations.
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct Point {
+    /// The x-coordinate
+    pub x: f32,
+    /// The y-coordinate (result of evaluating the equation at x)
+    pub y: f32,
+}
+
+impl Point {
+    /// Creates a new Point with the given coordinates.
+    pub(crate) fn new(x: f32, y: f32) -> Point {
+        Point { x, y }
+    }
+}
+
 pub(crate) type CellMatrix = Vec<Vec<Cell>>;
 pub(crate) type CharMatrix = Vec<Vec<char>>;
 pub(crate) type PointMatrix = Vec<Vec<Point>>;

--- a/src/modules/graphing.rs
+++ b/src/modules/graphing.rs
@@ -1,15 +1,12 @@
 use crate::modules::{
     common::{
         get_braille, make_cell_matrix, CellMatrix, CharMatrix, GraphOptions, NormalizedPoint,
-        PointMatrix,
+        Point, PointMatrix,
     },
     string_maker::make_graph_string,
 };
 
-use rusty_maths::{
-    equation_analyzer::calculator::{plot, Point},
-    utilities::abs_f32,
-};
+use rusty_maths::{equation_analyzer::calculator::plot, utilities::abs_f32};
 use std::sync::Arc;
 use std::thread;
 
@@ -35,7 +32,11 @@ pub(crate) fn graph(
     let mut points_collection: PointMatrix = Vec::with_capacity(eqs.len());
 
     for eq in eqs {
-        let points: Vec<Point> = plot(eq, x_min, x_max, x_step)?;
+        let rm_points = plot(eq, x_min, x_max, x_step)?;
+        let points: Vec<Point> = rm_points
+            .into_iter()
+            .map(|p| Point::new(p.x, p.y))
+            .collect();
 
         let y_min_actual: f32 = get_y_min(&points);
         let y_max_actual: f32 = get_y_max(&points);

--- a/src/modules/run.rs
+++ b/src/modules/run.rs
@@ -91,7 +91,11 @@ pub(crate) fn as_cli_tool(args: &[String], l: &mut impl Logger) {
                 {
                     if x_min < x_max {
                         let points = plot(&args[2], x_min, x_max, step_size);
-                        if let Ok(points) = points {
+                        if let Ok(rm_points) = points {
+                            let points: Vec<_> = rm_points
+                                .into_iter()
+                                .map(|p| crate::modules::common::Point::new(p.x, p.y))
+                                .collect();
                             let t = make_table_string(points);
                             l.print(&t);
                         } else if let Err(p) = points {

--- a/src/modules/string_maker.rs
+++ b/src/modules/string_maker.rs
@@ -1,4 +1,4 @@
-use rusty_maths::equation_analyzer::calculator::Point;
+use crate::modules::common::Point;
 use std::fmt::Write;
 
 const UPPER_LEFT: &str = "┌";

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -2,10 +2,8 @@
 mod rmr_tests {
     use std::collections::HashMap;
 
-    use rusty_maths::equation_analyzer::calculator::Point;
-
     use crate::modules::{
-        common::GraphOptions,
+        common::{GraphOptions, Point},
         evaluate::{evaluate, simple_evaluate},
         graphing::graph,
         logger::Logger,


### PR DESCRIPTION
The rusty-maths library update made the Point struct private. This commit implements a local Point struct that matches the rusty-maths API, allowing the code to compile while maintaining compatibility with the updated dependency.

Changes:
- Added local Point struct definition in common.rs
- Updated all imports to use local Point instead of rusty-maths Point
- Added conversion logic where plot() returns rusty-maths Points