### PR TITLE
Add adjustable decimal precision via :p command

### DIFF
--- a/src/modules/commands.rs
+++ b/src/modules/commands.rs
@@ -23,6 +23,11 @@ use super::{
 };
 
 pub(crate) fn run_command(line: &str, l: &mut impl Logger, repl: &mut Repl) {
+    if let Some(n) = line.strip_prefix("p ").or_else(|| line.strip_prefix("precision ")) {
+        set_precision(n, repl, l);
+        return;
+    }
+
     let go = GraphOptions {
         y_min: -7.,
         y_max: 7.,
@@ -64,7 +69,18 @@ fn h(l: &mut impl Logger) {
     l.print(":c  | :cube | :3d -> renders an animated cube to the terminal");
     l.print(":qbc -> quadratic bezier curve");
     l.print(":cbc -> cubic bezier curve");
+    l.print(":p  | :precision <n> -> set decimal precision (e.g. :p 4)");
     l.print(":q  | :quit -> exits the repl session");
+}
+
+fn set_precision(n: &str, repl: &mut Repl, l: &mut impl Logger) {
+    match n.trim().parse::<usize>() {
+        Ok(p) => {
+            repl.precision = p;
+            l.print(&format!("Precision set to {p}"));
+        }
+        Err(_) => l.eprint(&format!("'{n}' is not a valid precision value")),
+    }
 }
 
 fn cbc(l: &mut impl Logger, go: &GraphOptions) {

--- a/src/modules/evaluate.rs
+++ b/src/modules/evaluate.rs
@@ -8,8 +8,10 @@ pub(crate) fn evaluate(line: &str, repl: &mut Repl, l: &mut impl Logger) {
     let val = calculate(&line_internal);
     if let Ok(v) = val {
         repl.set_previous_answer(&v);
-        let f_v = format!("{v:.2}");
-        l.print(f_v.trim_end_matches(".00"));
+        let p = repl.precision;
+        let f_v = format!("{v:.p$}");
+        let trailing = format!(".{}", "0".repeat(p));
+        l.print(f_v.trim_end_matches(&trailing));
     } else if let Err(v) = val {
         repl.invalidate_prev_answer();
         l.eprint(&v);

--- a/src/modules/repl.rs
+++ b/src/modules/repl.rs
@@ -7,6 +7,7 @@ pub(crate) struct Repl {
 
     pub(crate) height: usize,
     pub(crate) width: usize,
+    pub(crate) precision: usize,
 }
 
 //the Repl object is a user session object
@@ -21,6 +22,7 @@ impl Repl {
             variables: HashMap::new(),
             height: width / 2,
             width,
+            precision: 2,
         }
     }
 

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -34,6 +34,7 @@ mod rmr_tests {
             variables: HashMap::new(),
             width: 240,
             height: 120,
+            precision: 2,
         }
     }
 


### PR DESCRIPTION
## What changed

- Added `precision: usize` to `Repl` (default `2`, matching previous behaviour)
- `evaluate` now reads `repl.precision` instead of a hardcoded `.2` format spec; trailing-zero stripping is also dynamic (e.g. precision 4 strips `.0000`)
- New command `:p <n>` / `:precision <n>` sets precision at runtime and confirms with a message
- Help text updated with the new command

## Usage

```
>> 1/3
0.33
>> :p 6
Precision set to 6
>> 1/3
0.333333
>> :p 0
Precision set to 0
>> 1/3
0
```