### PR TITLE
Fix REPL prompt wrapping with long input

### DIFF
--- a/src/modules/run.rs
+++ b/src/modules/run.rs
@@ -46,7 +46,7 @@ pub(crate) fn as_repl(l: &mut impl Logger) {
 
 fn build_interface() -> Result<Interface<DefaultTerminal>, Box<dyn Error>> {
     let interface = Interface::new("rmr-repl")?;
-    interface.set_prompt("\x1b[38;2;196;85;8m>> \x1b[0m")?;
+    interface.set_prompt("\x01\x1b[38;2;196;85;8m\x02>> \x01\x1b[0m\x02")?;
     Ok(interface)
 }
 


### PR DESCRIPTION
## Summary
- Wrap the prompt's ANSI color escapes in `\x01...\x02` markers so `linefeed` treats them as zero-width.
- Previously, `linefeed` counted the escape bytes as visible characters and miscalculated where the terminal edge was, causing the line to render incorrectly once input grew long enough to wrap.

## Why
Reported as: "if I type in an operation that is longer it gets all janky." Root cause is the same convention readline uses (`\[` / `\]`) — without the zero-width markers, prompt width is overcounted by the length of the SGR sequence.

## Test plan
- [ ] `cargo build` (passes locally)
- [ ] Run `rmr`, type an expression longer than the terminal width, confirm the line wraps cleanly and the cursor tracks correctly.
- [ ] Confirm the prompt still renders in orange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)