### PR TITLE
Add tab completion and :sg scrollable graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ g(x) = a * x^2
 :o  | :graph options      set graph width
 :ag | :animated graph     graph that zooms out over time
 :ig | :interactive graph  graph that pans with the arrow keys (q to quit)
+:sg | :scrollable graph   cursor walks the curve with a live x/y readout
+                          (←/→ move, ↑/↓ switch equations, q to quit)
 :la | :linear algebra     vector ops (vs = sum, vm = mean, b = back)
 :c  | :cube | :3d         animated cube
 :qbc / :cbc               quadratic / cubic bezier curves

--- a/src/modules/commands.rs
+++ b/src/modules/commands.rs
@@ -66,6 +66,9 @@ pub(crate) fn run_command(line: &str, l: &mut impl Logger, repl: &mut Repl) {
         "o" | "graph options" => gos(l, repl),
         "ag" | "animated graph" => ag(l, &go, &repl.defs),
         "ig" | "interactive graph" => ig(l, &go, &repl.defs),
+        "sg" | "scrollable graph" => {
+            crate::modules::scrollable_graph::sg(l, &go, &repl.defs, repl.precision)
+        }
         "la" | "linear algebra" => la(l),
         "c" | "cube" | "3d" => c(l, &go),
         "qbc" => qbc(l, &go),
@@ -86,6 +89,7 @@ fn h(l: &mut impl Logger) {
     l.print(":o  | :graph options -> graph options mode");
     l.print(":ag | :animated graph -> animated graph mode");
     l.print(":ig | :interactive graph -> interactive graph mode");
+    l.print(":sg | :scrollable graph -> walk a cursor along the curve (←/→ move, ↑/↓ switch equations, q quits)");
     l.print(":la | :linear algebra -> linear algebra mode");
     l.print(":c  | :cube | :3d -> renders an animated cube to the terminal");
     l.print(":qbc -> quadratic bezier curve");

--- a/src/modules/completion.rs
+++ b/src/modules/completion.rs
@@ -1,0 +1,204 @@
+//! Tab completion for the repl: `:commands`, catalog names, and the
+//! user's own `let` bindings.
+//!
+//! Completion candidates come from three places — the command list here,
+//! the engine's catalog, and a snapshot of the current bindings that the
+//! repl loop refreshes before each read. Functions complete with a
+//! trailing `(`, `log` with its `_` base syntax, values and constants
+//! bare.
+
+use linefeed::complete::{Completer, Completion, Suffix};
+use linefeed::prompter::Prompter;
+use linefeed::terminal::Terminal;
+use rusty_maths::equation_analyzer::{
+    catalog::{self, SymbolKind},
+    Definition, Definitions,
+};
+use std::sync::Mutex;
+
+/// Word-break characters for the repl: whitespace, operators, and
+/// delimiters. `:` is deliberately not a break so `:gr<TAB>` completes as
+/// one word.
+pub(crate) const WORD_BREAK_CHARS: &str = " \t+-*/^%(),=!|<>";
+
+/// Every repl command, with whether it takes an argument (those complete
+/// with a trailing space).
+const COMMANDS: &[(&str, bool)] = &[
+    (":g", false),
+    (":graph", false),
+    (":t", false),
+    (":table", false),
+    (":o", false),
+    (":ag", false),
+    (":ig", false),
+    (":la", false),
+    (":c", false),
+    (":cube", false),
+    (":3d", false),
+    (":qbc", false),
+    (":cbc", false),
+    (":p", true),
+    (":precision", true),
+    (":fns", false),
+    (":functions", false),
+    (":undef", true),
+    (":clear", false),
+    (":h", false),
+    (":help", false),
+    (":q", false),
+    (":quit", false),
+];
+
+pub(crate) struct RmrCompleter {
+    /// `(name, is_function)` for the current bindings; refreshed by the
+    /// repl loop via [`sync`](Self::sync) before each prompt.
+    bindings: Mutex<Vec<(String, bool)>>,
+}
+
+impl RmrCompleter {
+    pub(crate) fn new() -> Self {
+        RmrCompleter {
+            bindings: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Snapshots the current definitions (including `ans` once it exists).
+    pub(crate) fn sync(&self, defs: &Definitions) {
+        let names = defs
+            .iter()
+            .map(|d| match d {
+                Definition::Value { name, .. } => (name.to_string(), false),
+                Definition::Function { name, .. } => (name.to_string(), true),
+            })
+            .collect();
+        if let Ok(mut bindings) = self.bindings.lock() {
+            *bindings = names;
+        }
+    }
+}
+
+impl<Term: Terminal> Completer<Term> for RmrCompleter {
+    fn complete(
+        &self,
+        word: &str,
+        prompter: &Prompter<Term>,
+        start: usize,
+        _end: usize,
+    ) -> Option<Vec<Completion>> {
+        let before = &prompter.buffer()[..start];
+        let bindings = self.bindings.lock().ok()?;
+        let found = candidates(word, before, &bindings);
+        if found.is_empty() {
+            return None;
+        }
+        Some(
+            found
+                .into_iter()
+                .map(|(text, suffix)| Completion {
+                    completion: text,
+                    display: None,
+                    suffix: match suffix {
+                        Some(c) => Suffix::Some(c),
+                        None => Suffix::None,
+                    },
+                })
+                .collect(),
+        )
+    }
+}
+
+/// The completions for `word`, given the text `before` it on the line and
+/// the current bindings. Returned as `(text, optional suffix char)`,
+/// sorted; pure so it's testable without a terminal.
+pub(crate) fn candidates(
+    word: &str,
+    before: &str,
+    bindings: &[(String, bool)],
+) -> Vec<(String, Option<char>)> {
+    let mut out: Vec<(String, Option<char>)> = Vec::new();
+
+    // Completing the command itself.
+    if word.starts_with(':') {
+        for (cmd, takes_arg) in COMMANDS {
+            if cmd.starts_with(word) {
+                out.push(((*cmd).to_string(), takes_arg.then_some(' ')));
+            }
+        }
+        out.sort();
+        return out;
+    }
+
+    let context = before.trim();
+
+    // `:undef <name>` — only bindings can be removed.
+    if context == ":undef" {
+        for (name, _) in bindings {
+            if name.starts_with(word) {
+                out.push((name.clone(), None));
+            }
+        }
+        out.sort();
+        return out;
+    }
+
+    // `:fns <name>` — name lookup, so no call-syntax suffixes.
+    if context == ":fns" || context == ":functions" {
+        for name in catalog_names() {
+            if name.starts_with(word) {
+                out.push((name.to_string(), None));
+            }
+        }
+        for (name, _) in bindings {
+            if name.starts_with(word) {
+                out.push((name.clone(), None));
+            }
+        }
+        out.sort();
+        return out;
+    }
+
+    // An expression: catalog entries and bindings, functions opening their
+    // call; `let` offered at the start of a line.
+    if before.trim().is_empty() && "let".starts_with(word) && !word.is_empty() {
+        out.push(("let".to_string(), Some(' ')));
+    }
+    for sym in catalog::all() {
+        let suffix = match sym.kind {
+            SymbolKind::Unary(_) | SymbolKind::UnaryChecked(_) | SymbolKind::Variadic { .. } => {
+                Some('(')
+            }
+            SymbolKind::LogBase => Some('_'),
+            // Word operators (`mod`) complete bare; the variable `x` and
+            // glyph operators aren't worth a keystroke.
+            SymbolKind::Constant(_) | SymbolKind::Operator { .. } => None,
+            SymbolKind::Variable => continue,
+        };
+        for name in std::iter::once(sym.name).chain(sym.aliases.iter().copied()) {
+            if identifier_like(name) && name.starts_with(word) {
+                out.push((name.to_string(), suffix));
+            }
+        }
+    }
+    for (name, is_function) in bindings {
+        if name.starts_with(word) {
+            out.push((name.clone(), is_function.then_some('(')));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Catalog labels that lex as identifiers (skips operator glyphs, keeps
+/// word operators like `mod`).
+fn catalog_names() -> impl Iterator<Item = &'static str> {
+    catalog::all()
+        .iter()
+        .filter(|s| !matches!(s.kind, SymbolKind::Variable))
+        .flat_map(|s| std::iter::once(s.name).chain(s.aliases.iter().copied()))
+        .filter(|name| identifier_like(name))
+}
+
+/// Typeable-as-a-word names only — `mod` yes, `%%` and `|>` no.
+fn identifier_like(name: &str) -> bool {
+    name.chars().next().is_some_and(char::is_alphabetic)
+}

--- a/src/modules/completion.rs
+++ b/src/modules/completion.rs
@@ -31,6 +31,7 @@ const COMMANDS: &[(&str, bool)] = &[
     (":o", false),
     (":ag", false),
     (":ig", false),
+    (":sg", false),
     (":la", false),
     (":c", false),
     (":cube", false),

--- a/src/modules/graphing.rs
+++ b/src/modules/graphing.rs
@@ -36,6 +36,19 @@ pub(crate) fn graph(
     go: &GraphOptions,
     defs: &Definitions,
 ) -> Result<String, EquationError> {
+    graph_with_view(eq_str, x_min, x_max, go, defs).map(|(g, _, _)| g)
+}
+
+/// Like [`graph`], but also returns the y-range the auto-fit settled on —
+/// callers that draw *onto* the rendered graph (the `:sg` cursor) need the
+/// same view mapping the plot used.
+pub(crate) fn graph_with_view(
+    eq_str: &str,
+    x_min: f32,
+    x_max: f32,
+    go: &GraphOptions,
+    defs: &Definitions,
+) -> Result<(String, f32, f32), EquationError> {
     let mut y_min: f32 = go.y_min;
     let mut y_max: f32 = go.y_max;
 
@@ -132,10 +145,8 @@ pub(crate) fn graph(
 
     let braille_chars: CharMatrix = get_braille(go, &mut matrix);
 
-    Ok(make_graph_string(
-        braille_chars,
-        x_min,
-        x_max,
+    Ok((
+        make_graph_string(braille_chars, x_min, x_max, master_y_min, master_y_max),
         master_y_min,
         master_y_max,
     ))

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -11,5 +11,6 @@ pub(crate) mod inputs;
 pub(crate) mod logger;
 pub(crate) mod repl;
 pub(crate) mod run;
+pub(crate) mod scrollable_graph;
 pub(crate) mod string_maker;
 pub(crate) mod tests;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod bezier_curve;
 pub(crate) mod bindings;
 pub(crate) mod commands;
 pub(crate) mod common;
+pub(crate) mod completion;
 pub(crate) mod cube;
 pub(crate) mod error_render;
 pub(crate) mod evaluate;

--- a/src/modules/run.rs
+++ b/src/modules/run.rs
@@ -4,11 +4,12 @@ use std::{cmp::Ordering, error::Error};
 use rusty_maths::equation_analyzer::{calculator::plot, Definitions};
 
 use crate::modules::{
-    bindings, commands, common::GraphOptions, error_render, evaluate, graphing, logger::Logger,
-    repl, string_maker::make_table_string,
+    bindings, commands, common::GraphOptions, completion, error_render, evaluate, graphing,
+    logger::Logger, repl, string_maker::make_table_string,
 };
 
 use linefeed::{DefaultTerminal, Interface, ReadResult};
+use std::sync::Arc;
 
 pub(crate) fn as_repl(l: &mut impl Logger) {
     l.print("\n--rusty maths repl--\n");
@@ -18,7 +19,20 @@ pub(crate) fn as_repl(l: &mut impl Logger) {
     bindings::load(&mut repl, l);
 
     if let Ok(interface) = build_interface() {
-        while let Ok(ReadResult::Input(line)) = interface.read_line() {
+        let completer = Arc::new(completion::RmrCompleter::new());
+        interface.set_completer(completer.clone());
+        interface
+            .lock_reader()
+            .set_word_break_chars(completion::WORD_BREAK_CHARS);
+
+        loop {
+            // Refresh the completion snapshot so new bindings (and `ans`)
+            // are tab-completable immediately.
+            completer.sync(&repl.defs);
+
+            let Ok(ReadResult::Input(line)) = interface.read_line() else {
+                break;
+            };
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;

--- a/src/modules/scrollable_graph.rs
+++ b/src/modules/scrollable_graph.rs
@@ -1,0 +1,220 @@
+//! `:sg` — scrollable graph. The window stays fixed while a cursor walks
+//! the curve, with a live coordinate readout above the frame:
+//!
+//! ```text
+//! y = sin(x^2) │ x: 1.25  y: 0.95
+//! ┌────────────────────────┐1.50
+//! │      ⡴⠋⠈●⡆    ⢀⡖⠑⡄      │
+//! ...
+//! ```
+//!
+//! Left/Right move the cursor one braille column of x at a time, Up/Down
+//! switch between `|`-separated equations, `q` quits. The marker is drawn
+//! *onto* the rendered graph — character surgery after rasterization —
+//! because a cursor should stand apart from the data, unlike the axes,
+//! which live in the cell matrix and blend with it.
+
+use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use crossterm::{cursor, ExecutableCommand};
+use rusty_maths::equation_analyzer::{calculator::plot_with, Definitions};
+
+use crate::modules::{
+    common::GraphOptions, error_render, graphing, inputs::get_g_inputs, logger::Logger,
+};
+
+const MARKER: char = '●';
+
+/// The fixed view a session scrolls within: the rendered base graph plus
+/// the world-to-cell mapping parameters it was rendered with.
+struct View {
+    base: String,
+    x_min: f32,
+    x_max: f32,
+    y_min: f32,
+    y_max: f32,
+    width: usize,
+    height: usize,
+}
+
+pub(crate) fn sg(l: &mut impl Logger, go: &GraphOptions, defs: &Definitions, precision: usize) {
+    let (eq, x_min, x_max) = get_g_inputs(l);
+
+    let (base, y_min, y_max) = match graphing::graph_with_view(&eq, x_min, x_max, go, defs) {
+        Ok(v) => v,
+        Err(e) => {
+            l.eprint(&error_render::render_error_with_source(&eq, &e, defs));
+            return;
+        }
+    };
+    let view = View {
+        base,
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        width: go.width,
+        height: go.height,
+    };
+
+    let eqs: Vec<&str> = eq.split('|').map(str::trim).collect();
+    let mut active = 0usize;
+    let mut cursor_x = (x_min + x_max) / 2.0;
+    // One braille character column of x per keypress.
+    let x_step = (x_max - x_min) / view.width as f32 * 2.0;
+
+    let mut stdout = std::io::stdout();
+    let mut drawn = draw(l, &view, &eqs, active, cursor_x, defs, precision);
+
+    // Enable raw mode for key capture - ignore errors, continue without
+    // interactive mode (matches :ig).
+    let _ = enable_raw_mode();
+    loop {
+        let Ok(Event::Key(KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            ..
+        })) = read()
+        else {
+            continue;
+        };
+
+        match code {
+            KeyCode::Left => cursor_x = (cursor_x - x_step).max(view.x_min),
+            KeyCode::Right => cursor_x = (cursor_x + x_step).min(view.x_max),
+            KeyCode::Up => active = (active + 1) % eqs.len(),
+            KeyCode::Down => active = (active + eqs.len() - 1) % eqs.len(),
+            KeyCode::Char('q') => break,
+            _ => continue,
+        }
+
+        let _ = disable_raw_mode();
+        let _ = stdout.execute(cursor::MoveUp(drawn as u16));
+        drawn = draw(l, &view, &eqs, active, cursor_x, defs, precision);
+        let _ = enable_raw_mode();
+    }
+    let _ = disable_raw_mode();
+}
+
+/// Prints the readout line and the marked graph; returns how many terminal
+/// lines that was, so the caller can move back up over them.
+fn draw(
+    l: &mut impl Logger,
+    view: &View,
+    eqs: &[&str],
+    active: usize,
+    cursor_x: f32,
+    defs: &Definitions,
+    precision: usize,
+) -> usize {
+    let y = eval_at(eqs[active], cursor_x, defs);
+
+    let which = if eqs.len() > 1 {
+        format!("[{}/{}] ", active + 1, eqs.len())
+    } else {
+        String::new()
+    };
+    let y_text = match y {
+        Some(v) => format!("{v:.precision$}"),
+        None => "undefined".to_string(),
+    };
+    let readout = format!(
+        "{which}{} │ x: {cursor_x:.precision$}  y: {y_text}",
+        eqs[active]
+    );
+    // Pad to the frame width so a shorter readout fully overwrites the
+    // previous one during in-place redraws.
+    let frame_width = view.width / 2 + 2;
+    l.print(&format!("{readout:<frame_width$}"));
+
+    let marked = overlay_marker(&view.base, marker_cell(cursor_x, y, view));
+    l.print(&marked);
+
+    1 + marked.lines().count()
+}
+
+/// The y value of one equation at one x, or None where it doesn't evaluate
+/// to a plottable number.
+fn eval_at(eq: &str, x: f32, defs: &Definitions) -> Option<f32> {
+    plot_with(eq, x, x, 1.0, defs)
+        .ok()
+        .and_then(|points| points.first().map(|p| p.y))
+        .filter(|y| y.is_finite())
+}
+
+/// Maps a world-space cursor position onto a braille character cell —
+/// `(row, col)` within the graph's braille grid, row 0 at the top. The
+/// same normalization the plotter uses, at character resolution; y is
+/// clamped so an off-view cursor pins to the frame edge.
+fn marker_cell(cursor_x: f32, y: Option<f32>, view: &View) -> Option<(usize, usize)> {
+    let y = y?;
+    let char_rows = view.height / 4;
+    let char_cols = view.width / 2;
+    if char_rows == 0 || char_cols == 0 {
+        return None;
+    }
+
+    let fx = ((cursor_x - view.x_min) / (view.x_max - view.x_min)).clamp(0.0, 1.0);
+    let fy = ((y - view.y_min) / (view.y_max - view.y_min)).clamp(0.0, 1.0);
+
+    let col = ((fx * view.width as f32) as usize / 2).min(char_cols - 1);
+    let row_from_bottom = ((fy * view.height as f32) as usize / 4).min(char_rows - 1);
+    let row = char_rows - 1 - row_from_bottom;
+
+    Some((row, col))
+}
+
+/// Replaces one braille cell of the rendered graph with the marker.
+/// `cell` is (row, col) in the braille grid; the +1 offsets skip the box
+/// border. `None` leaves the graph untouched.
+fn overlay_marker(base: &str, cell: Option<(usize, usize)>) -> String {
+    let Some((row, col)) = cell else {
+        return base.to_string();
+    };
+
+    let mut lines: Vec<String> = base.lines().map(str::to_string).collect();
+    if let Some(line) = lines.get_mut(row + 1) {
+        let target = col + 1;
+        *line = line
+            .chars()
+            .enumerate()
+            .map(|(i, c)| if i == target { MARKER } else { c })
+            .collect();
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Test-only doorway to the pure marker math.
+    pub(crate) fn marker_cell_for(
+        cursor_x: f32,
+        y: Option<f32>,
+        x_min: f32,
+        x_max: f32,
+        y_min: f32,
+        y_max: f32,
+        width: usize,
+        height: usize,
+    ) -> Option<(usize, usize)> {
+        marker_cell(
+            cursor_x,
+            y,
+            &View {
+                base: String::new(),
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+                width,
+                height,
+            },
+        )
+    }
+
+    pub(crate) fn overlay(base: &str, cell: Option<(usize, usize)>) -> String {
+        overlay_marker(base, cell)
+    }
+}

--- a/src/modules/scrollable_graph.rs
+++ b/src/modules/scrollable_graph.rs
@@ -23,7 +23,11 @@ use crate::modules::{
     common::GraphOptions, error_render, graphing, inputs::get_g_inputs, logger::Logger,
 };
 
-const MARKER: char = '●';
+/// The cursor is a reverse-video highlight of the cell it sits on, so the
+/// curve's own dots stay visible inside the marker (an empty cell shows as
+/// a solid block).
+pub(crate) const MARKER_START: &str = "\u{001b}[7m";
+pub(crate) const MARKER_END: &str = "\u{001b}[27m";
 
 /// The fixed view a session scrolls within: the rendered base graph plus
 /// the world-to-cell mapping parameters it was rendered with.
@@ -143,9 +147,15 @@ fn eval_at(eq: &str, x: f32, defs: &Definitions) -> Option<f32> {
 }
 
 /// Maps a world-space cursor position onto a braille character cell —
-/// `(row, col)` within the graph's braille grid, row 0 at the top. The
-/// same normalization the plotter uses, at character resolution; y is
-/// clamped so an off-view cursor pins to the frame edge.
+/// `(row, col)` within the graph's braille grid, row 0 at the top.
+///
+/// This replays the plotter's own pipeline step for step, because any
+/// shortcut drifts by a cell: y snaps to the *nearest* bin (the binary
+/// search's rounding), the bin index flips like `matrix.reverse()`, and
+/// rows group into fours anchored at the top — with `height + 1` matrix
+/// rows the leftover partial row falls at the bottom, so a bottom-anchored
+/// mirror is off by one. Off-view y clamps so the cursor pins to the
+/// frame edge.
 fn marker_cell(cursor_x: f32, y: Option<f32>, view: &View) -> Option<(usize, usize)> {
     let y = y?;
     let char_rows = view.height / 4;
@@ -157,14 +167,20 @@ fn marker_cell(cursor_x: f32, y: Option<f32>, view: &View) -> Option<(usize, usi
     let fx = ((cursor_x - view.x_min) / (view.x_max - view.x_min)).clamp(0.0, 1.0);
     let fy = ((y - view.y_min) / (view.y_max - view.y_min)).clamp(0.0, 1.0);
 
+    // x truncates — the plotter's sample-index-to-column mapping truncates.
     let col = ((fx * view.width as f32) as usize / 2).min(char_cols - 1);
-    let row_from_bottom = ((fy * view.height as f32) as usize / 4).min(char_rows - 1);
-    let row = char_rows - 1 - row_from_bottom;
+
+    // y rounds to the nearest bin edge (0..=height, like the binary
+    // search), flips (like matrix.reverse()), then groups by 4 from the
+    // top (like get_braille).
+    let y_bin = ((fy * view.height as f32).round() as usize).min(view.height);
+    let display_row = view.height - y_bin;
+    let row = (display_row / 4).min(char_rows - 1);
 
     Some((row, col))
 }
 
-/// Replaces one braille cell of the rendered graph with the marker.
+/// Highlights one braille cell of the rendered graph in reverse video.
 /// `cell` is (row, col) in the braille grid; the +1 offsets skip the box
 /// border. `None` leaves the graph untouched.
 fn overlay_marker(base: &str, cell: Option<(usize, usize)>) -> String {
@@ -178,7 +194,13 @@ fn overlay_marker(base: &str, cell: Option<(usize, usize)>) -> String {
         *line = line
             .chars()
             .enumerate()
-            .map(|(i, c)| if i == target { MARKER } else { c })
+            .map(|(i, c)| {
+                if i == target {
+                    format!("{MARKER_START}{c}{MARKER_END}")
+                } else {
+                    c.to_string()
+                }
+            })
             .collect();
     }
     lines.join("\n")

--- a/src/modules/scrollable_graph.rs
+++ b/src/modules/scrollable_graph.rs
@@ -189,6 +189,7 @@ pub(crate) mod test_support {
     use super::*;
 
     /// Test-only doorway to the pure marker math.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn marker_cell_for(
         cursor_x: f32,
         y: Option<f32>,

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -505,6 +505,66 @@ mod rmr_tests {
         assert_eq!(got, vec![("growth".to_string(), None)]);
     }
 
+    // ============================================================================
+    // :sg marker math
+    // ============================================================================
+
+    #[test]
+    fn sg_marker_cell_maps_world_to_braille_grid() {
+        use crate::modules::scrollable_graph::test_support::marker_cell_for;
+
+        // 240x120 subpixels = 120x30 chars. Center of a symmetric view
+        // lands in the center cell.
+        let cell = marker_cell_for(0.0, Some(0.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
+        assert_eq!(cell, Some((14, 60)));
+
+        // Left edge, bottom edge.
+        let cell = marker_cell_for(-1.0, Some(-1.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
+        assert_eq!(cell, Some((29, 0)));
+
+        // Top-right corner clamps into the grid.
+        let cell = marker_cell_for(1.0, Some(1.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
+        assert_eq!(cell, Some((0, 119)));
+
+        // Off-view y pins to the frame edge rather than escaping it.
+        let cell = marker_cell_for(0.0, Some(50.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
+        assert_eq!(cell, Some((0, 60)));
+
+        // No value, no marker.
+        assert_eq!(
+            marker_cell_for(0.0, None, -1.0, 1.0, -1.0, 1.0, 240, 120),
+            None
+        );
+    }
+
+    #[test]
+    fn sg_overlay_replaces_one_cell_inside_the_frame() {
+        use crate::modules::scrollable_graph::test_support::overlay;
+
+        let base = "┌──┐1.0\n│⠉⠉│\n│⣀⣀│\n└──┘-1.0\n-1  1";
+
+        // Row 0, col 1 → second braille cell of the first graph line.
+        let marked = overlay(base, Some((0, 1)));
+        assert_eq!(marked, "┌──┐1.0\n│⠉●│\n│⣀⣀│\n└──┘-1.0\n-1  1");
+
+        // Borders and labels are untouched; None is a no-op.
+        assert_eq!(overlay(base, None), base);
+    }
+
+    #[test]
+    fn sg_readout_evaluates_with_bindings() {
+        // eval_at goes through plot_with, so `:sg` sees user functions —
+        // exercised here via the same public path the readout uses.
+        use rusty_maths::equation_analyzer::calculator::plot_with;
+
+        let (mut repl, mut test_logger) = get_repl_and_logger();
+        let_line("let g(x) = 2x^2", &mut repl, &mut test_logger);
+
+        let points = plot_with("y = g(x)", 3.0, 3.0, 1.0, &repl.defs).unwrap();
+        assert_eq!(points.len(), 1);
+        assert_eq!(points[0].y, 18.0);
+    }
+
     #[test]
     fn undef_command_routes_through_run_command() {
         use crate::modules::commands::run_command;

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -513,18 +513,27 @@ mod rmr_tests {
     fn sg_marker_cell_maps_world_to_braille_grid() {
         use crate::modules::scrollable_graph::test_support::marker_cell_for;
 
-        // 240x120 subpixels = 120x30 chars. Center of a symmetric view
-        // lands in the center cell.
+        // 240x120 subpixels = 120x30 chars. This mirrors the plotter's own
+        // pipeline: y rounds to nearest bin (0..=120), flips, groups by 4
+        // from the top. Center of a symmetric view: bin 60 → display row
+        // 60 → char row 15.
         let cell = marker_cell_for(0.0, Some(0.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
-        assert_eq!(cell, Some((14, 60)));
+        assert_eq!(cell, Some((15, 60)));
 
-        // Left edge, bottom edge.
+        // Left edge, bottom edge: bin 0 → display row 120 → clamps into
+        // the last char row (the partial leftover row isn't rendered).
         let cell = marker_cell_for(-1.0, Some(-1.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
         assert_eq!(cell, Some((29, 0)));
 
         // Top-right corner clamps into the grid.
         let cell = marker_cell_for(1.0, Some(1.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
         assert_eq!(cell, Some((0, 119)));
+
+        // Nearest-bin rounding, not truncation: a y just above a bin
+        // midpoint snaps up. y = 0.24 in -1..1 → fy = 0.62 → bin
+        // round(74.4) = 74 → display 46 → char row 11.
+        let cell = marker_cell_for(0.0, Some(0.24), -1.0, 1.0, -1.0, 1.0, 240, 120);
+        assert_eq!(cell, Some((11, 60)));
 
         // Off-view y pins to the frame edge rather than escaping it.
         let cell = marker_cell_for(0.0, Some(50.0), -1.0, 1.0, -1.0, 1.0, 240, 120);
@@ -538,14 +547,19 @@ mod rmr_tests {
     }
 
     #[test]
-    fn sg_overlay_replaces_one_cell_inside_the_frame() {
+    fn sg_overlay_highlights_one_cell_inside_the_frame() {
         use crate::modules::scrollable_graph::test_support::overlay;
+        use crate::modules::scrollable_graph::{MARKER_END, MARKER_START};
 
         let base = "┌──┐1.0\n│⠉⠉│\n│⣀⣀│\n└──┘-1.0\n-1  1";
 
-        // Row 0, col 1 → second braille cell of the first graph line.
+        // Row 0, col 1 → second braille cell of the first graph line gets
+        // reverse-videoed; the curve's own dots stay visible inside it.
         let marked = overlay(base, Some((0, 1)));
-        assert_eq!(marked, "┌──┐1.0\n│⠉●│\n│⣀⣀│\n└──┘-1.0\n-1  1");
+        assert_eq!(
+            marked,
+            format!("┌──┐1.0\n│⠉{MARKER_START}⠉{MARKER_END}│\n│⣀⣀│\n└──┘-1.0\n-1  1")
+        );
 
         // Borders and labels are untouched; None is a no-op.
         assert_eq!(overlay(base, None), base);

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -412,6 +412,99 @@ mod rmr_tests {
         assert!(!looks_like_binding("2 ^ 3"));
     }
 
+    // ============================================================================
+    // Tab completion candidates
+    // ============================================================================
+
+    #[test]
+    fn completion_commands() {
+        use crate::modules::completion::candidates;
+        let none: &[(String, bool)] = &[];
+
+        let got = candidates(":gr", ":gr", none);
+        assert_eq!(got, vec![(":graph".to_string(), None)]);
+
+        // Arg-taking commands complete with a trailing space.
+        let got = candidates(":un", ":un", none);
+        assert_eq!(got, vec![(":undef".to_string(), Some(' '))]);
+
+        let got = candidates(":q", ":q", none);
+        assert_eq!(
+            got,
+            vec![
+                (":q".to_string(), None),
+                (":qbc".to_string(), None),
+                (":quit".to_string(), None)
+            ]
+        );
+    }
+
+    #[test]
+    fn completion_expressions() {
+        use crate::modules::completion::candidates;
+        let bindings = vec![("growth".to_string(), true), ("gain".to_string(), false)];
+
+        // Functions open their call; values complete bare.
+        let got = candidates("g", "2 + ", &bindings);
+        assert_eq!(
+            got,
+            vec![
+                ("gain".to_string(), None),
+                ("growth".to_string(), Some('('))
+            ]
+        );
+
+        // Catalog functions, including aliases, get the paren too.
+        let got = candidates("sq", "", &[]);
+        assert_eq!(got, vec![("sqrt".to_string(), Some('('))]);
+        let got = candidates("arcsi", "", &[]);
+        assert_eq!(
+            got,
+            vec![
+                ("arcsin".to_string(), Some('(')),
+                ("arcsinh".to_string(), Some('(')),
+            ]
+        );
+
+        // log completes into its base syntax; constants and mod are bare.
+        let got = candidates("lo", "", &[]);
+        assert_eq!(got, vec![("log".to_string(), Some('_'))]);
+        let got = candidates("pi", "", &[]);
+        assert_eq!(got, vec![("pi".to_string(), None)]);
+        let got = candidates("mo", "17 ", &[]);
+        assert_eq!(
+            got,
+            vec![("mod".to_string(), None), ("mode".to_string(), Some('('))]
+        );
+
+        // `let` is offered only at the start of a line.
+        let got = candidates("le", "", &[]);
+        assert_eq!(got, vec![("let".to_string(), Some(' '))]);
+        let got = candidates("le", "2 + ", &[]);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn completion_command_arguments() {
+        use crate::modules::completion::candidates;
+        let bindings = vec![("growth".to_string(), true), ("gain".to_string(), false)];
+
+        // :undef completes binding names only, bare.
+        let got = candidates("g", ":undef ", &bindings);
+        assert_eq!(
+            got,
+            vec![("gain".to_string(), None), ("growth".to_string(), None)]
+        );
+        let got = candidates("si", ":undef ", &bindings);
+        assert!(got.is_empty());
+
+        // :fns completes names without call syntax.
+        let got = candidates("sq", ":fns ", &bindings);
+        assert_eq!(got, vec![("sqrt".to_string(), None)]);
+        let got = candidates("gr", ":fns ", &bindings);
+        assert_eq!(got, vec![("growth".to_string(), None)]);
+    }
+
     #[test]
     fn undef_command_routes_through_run_command() {
         use crate::modules::commands::run_command;

--- a/todo.txt
+++ b/todo.txt
@@ -6,7 +6,6 @@ make a logo
 
 command auto complete?
 
-make scrollable graph
 
 
 save graph to a txt file? some other file type? svg?


### PR DESCRIPTION
## Summary

Two features, one branch (per Shane):

### Tab completion (backlog #3)

linefeed `Completer` fed from three sources:
- **Commands**: `:gr<TAB>` → `:graph`; arg-taking commands (`:p`, `:undef`) complete with a trailing space.
- **The catalog**: functions complete with `(` (`sq<TAB>` → `sqrt(`), `log` completes to `log_`, constants and `mod` bare; aliases included.
- **Your bindings**: snapshot refreshed before every prompt — a fresh `let` (and `ans`) completes immediately. `:undef <TAB>` offers only bindings; `:fns <TAB>` completes names without call syntax; `let` offers at line start.

The candidate logic is a pure function (`completion::candidates`), fully unit-tested; the `Completer` impl is a thin adapter.

### `:sg` — scrollable graph

The window stays fixed while a cursor walks the curve: ←/→ move one braille column of x per press, ↑/↓ switch between `|`-separated equations, `q` quits. A readout above the frame shows the active equation and live `x:`/`y:` values at the repl's display precision — the graph becomes an instrument you can read values off.

- Marker overlays the *rendered* graph (character surgery at the cursor's cell) — a cursor should stand apart from the data, unlike axes which live in the cell matrix and blend with it.
- `graph_with_view` exposes the auto-fit y-range so the marker uses the exact same view mapping as the plot.
- Off-view y pins to the frame edge; NaN/inf reads `y: undefined` with no marker. User-defined functions work (evaluation goes through `plot_with`).

## Test plan

- 75 tests: completion candidates (commands/expressions/argument contexts) and `:sg` marker math (world→cell mapping incl. clamping, overlay surgery, binding evaluation path).
- fmt + clippy `-D warnings` clean.
- Raw-mode interaction needs a real terminal: try `:sg` with `sin(x^2)` and with `y=sin(x) | y=cos(x)` (↑/↓), plus a TAB or two for completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)