### PR TITLE
Fill each column's span so steep curves render gap-free

### DIFF
--- a/src/modules/graphing.rs
+++ b/src/modules/graphing.rs
@@ -110,6 +110,13 @@ pub(crate) fn graph(
     check_add_tick_marks(&mut matrix, x_min, x_max, master_y_min, master_y_max, go);
 
     for points in points_collection {
+        // Light the exact footprint. Within a column the curve sweeps a
+        // contiguous band of rows, so lighting only the sampled rows leaves
+        // gaps on steep sections. Record each column's min/max row and fill
+        // the span between them — gentle columns (min == max) are unchanged;
+        // steep columns close up into the full run of cells the curve covers.
+        let mut col_lo = vec![usize::MAX; go.width + 1];
+        let mut col_hi = vec![0usize; go.width + 1];
         for np in get_normalized_points(
             go.height,
             master_y_min,
@@ -119,7 +126,17 @@ pub(crate) fn graph(
         )
         .filter(|np| np.y_acc <= master_y_max && np.y_acc >= master_y_min)
         {
-            matrix[np.y][np.x].value = true;
+            if np.x <= go.width {
+                col_lo[np.x] = col_lo[np.x].min(np.y);
+                col_hi[np.x] = col_hi[np.x].max(np.y);
+            }
+        }
+        for x in 0..=go.width {
+            if col_lo[x] != usize::MAX {
+                for y in col_lo[x]..=col_hi[x] {
+                    matrix[y][x].value = true;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Renders the **exact footprint** of each curve, closing the vertical gaps that steep sections used to show.

Within a single column the x-axis advances only a sliver, so a continuous curve sweeps a *contiguous* band of rows there (intermediate value theorem — it touches every row between where it enters and leaves). The old render lit only the rows the sample points happened to land on, which on steep columns leaves holes. This records each column's min/max row and fills the span between them.

## What changes visually
- **Gentle / moderate curves** (`sin(x)`, `x^2`, most graphs, the wide CLI render): **byte-identical** — their columns were already complete.
- **Steep / near-vertical sections** (`tan(x)` asymptotes, `x^5` tails, `sin(5x)`, sharp transitions): the dots close up into solid vertical runs instead of gapping.
- **Never worse**: for a continuous curve the fill only adds rows the curve actually covers — it can't light a wrong cell or drop a right one.

## Why it's the right fix
It makes completeness a property of the *rendering*, not of getting the sampling density high enough. The graph is correct for any curve/width/height, independent of `SAMPLING_DIVISOR` (left at 16 — with fill on, it's already at the footprint ceiling for anything but tight wiggles on tiny terminals).

## Scope
`get_normalized_points` is untouched; only the rasterization loop in `graph()` changed (accumulate each column's row span, then fill it).

## Verification
- 69/69 tests pass.
- Confirmed by eye: `tan(x)`'s near-vertical sections render gap-free; gentle curves unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
