### PR TITLE
Rewrite comments to current state; fix needless_range_loop

### DIFF
--- a/src/modules/common.rs
+++ b/src/modules/common.rs
@@ -59,9 +59,7 @@ pub(crate) fn get_braille(go: &GraphOptions, matrix: &CellMatrix) -> CharMatrix 
     let mut chars: CharMatrix = vec![Vec::with_capacity(col_char_count); row_char_count];
 
     // Each braille glyph packs a 2-wide × 4-tall block of cells, so glyph
-    // origins land exactly on cells where row % 4 == 0 and col % 2 == 0. Step
-    // straight to those corners instead of walking every cell and skipping the
-    // 7 of 8 that a previous glyph already consumed.
+    // origins fall on cells where row % 4 == 0 and col % 2 == 0.
     for row in (0..matrix.len()).step_by(4) {
         if row / 4 >= chars.len() {
             break; // ragged final block with no glyph row to hold it

--- a/src/modules/graphing.rs
+++ b/src/modules/graphing.rs
@@ -110,11 +110,8 @@ pub(crate) fn graph(
     check_add_tick_marks(&mut matrix, x_min, x_max, master_y_min, master_y_max, go);
 
     for points in points_collection {
-        // Light the exact footprint. Within a column the curve sweeps a
-        // contiguous band of rows, so lighting only the sampled rows leaves
-        // gaps on steep sections. Record each column's min/max row and fill
-        // the span between them — gentle columns (min == max) are unchanged;
-        // steep columns close up into the full run of cells the curve covers.
+        // Within a column the curve sweeps a contiguous band of rows, so
+        // record each column's min/max row and fill the span between them.
         let mut col_lo = vec![usize::MAX; go.width + 1];
         let mut col_hi = vec![0usize; go.width + 1];
         for np in get_normalized_points(
@@ -133,8 +130,8 @@ pub(crate) fn graph(
         }
         for x in 0..=go.width {
             if col_lo[x] != usize::MAX {
-                for y in col_lo[x]..=col_hi[x] {
-                    matrix[y][x].value = true;
+                for row in &mut matrix[col_lo[x]..=col_hi[x]] {
+                    row[x].value = true;
                 }
             }
         }
@@ -220,15 +217,11 @@ pub(crate) fn get_normalized_points(
 
     let inverse_samp_factor = 1.0 / sampling_factor;
 
-    // Lazy: the caller filters and drains this straight into the matrix, so no
-    // intermediate Vec. The per-point work is a handful of float ops — far too
-    // little to pay for rayon's thread dispatch, so this stays serial.
+    // Lazy: the caller filters and drains this straight into the matrix.
     points.iter().enumerate().map(move |(i, point)| {
         let x = ((i as f32) * inverse_samp_factor) as usize;
 
-        // y_values would be the uniform ladder y_min + n*y_step for n in 0..=height.
-        // Since it's evenly spaced, invert the formula to get the nearest rung directly
-        // instead of building the ladder and searching it.
+        // Rows are evenly spaced (y_min + n*y_step), so map y to its nearest row directly.
         let y = if y_step == 0.0 {
             0
         } else {

--- a/src/modules/tests.rs
+++ b/src/modules/tests.rs
@@ -368,7 +368,7 @@ mod rmr_tests {
         let_line("let g(x) = a * x", &mut repl, &mut test_logger);
         bindings::undefine("a", &mut repl, &mut test_logger);
 
-        //When: g's body no longer resolves at call time
+        //When: g is called but `a`, used in its body, is undefined
         evaluate("g(2)", &mut repl, &mut test_logger);
 
         //Then: the error reprints the definition and carets into the body


### PR DESCRIPTION
## Summary
Documentation and lint cleanup — no behavior change.

## Changes
- **Comments**: rewrite comments in `graphing.rs` and `common.rs` (and one test comment) so they describe only the current behavior, with no references to prior implementations.
- **Lint**: fix a `clippy::needless_range_loop` in the column-span fill by iterating the matrix row slice (`&mut matrix[lo..=hi]`) instead of a range index.

## Verification
- 69 tests pass; clippy clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
